### PR TITLE
Made whitelist fetching threaded

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -17,8 +17,7 @@ buildscript {
 
 def BUILD_NUMBER = System.getenv("BUILD_NUMBER") ?: "0"
 
-sourceCompatibility = JavaVersion.VERSION_1_7
-targetCompatibility = JavaVersion.VERSION_1_7
+sourceCompatibility = targetCompatibility = JavaVersion.VERSION_1_8
 
 version = major_version + "." + minor_version + "." + BUILD_NUMBER
 group = "net.blay09.mods"


### PR DESCRIPTION
This is a proposal of how it could be made threaded as you wanted to to before a release from #2.
If you already have done it or part of it but not pushed you can ignore this.
Tested on server and client and it works as normal, don't have slow internet so can't test that.

It runs separate now and then merges back on the minecraft thread for changing the values for thread safety. It won't start multiple threads until previous ones is done. 